### PR TITLE
Update relative path of root index for generated api docs

### DIFF
--- a/lib/cli/build.js
+++ b/lib/cli/build.js
@@ -122,7 +122,7 @@ async function action(oapiSpecFile, cmd) {
   }
 
   const indexTemplate = await compilePage(Handlebars);
-  fs.writeFileSync(path.join(getOutputDir(outputDir), 'index.adoc'), indexTemplate(resourceIndex.sort(sortByKind)));
+  fs.writeFileSync(path.join(getOutputDir(outputDir), 'overview', 'index.adoc'), indexTemplate(resourceIndex.sort(sortByKind)));
 
   const used = [];
 

--- a/lib/models/definition.js
+++ b/lib/models/definition.js
@@ -8,6 +8,7 @@ function createDefinition(attrs = {}, definitions) {
 
   const attributes = {
     schemaId: '',
+    viewSchemaId: '',
 
     group: '',
     version: '',
@@ -55,6 +56,10 @@ function createDefinition(attrs = {}, definitions) {
     // TODO - template wants a property, but key() used above
     get key2() {
       return this.apiKey();
+    },
+
+    get viewSchemaId() {
+      return attributes.viewSchemaId;
     },
 
     get group() {

--- a/lib/openapi.js
+++ b/lib/openapi.js
@@ -91,9 +91,11 @@ function parseApiSpec({ spec = {} } = {}) {
   const [ definitions ] = Object.entries(spec['definitions']).reduce(([ m, apis ], [ schemaId, schema ]) => {
     const kgvs = schema[typeKey] || [];
     const { kind, group, version } = kgvs.length == 1 ? kgvs[0] : (kgvs.find(v => v.group != '') || {});
+    const viewSchemaId = schemaId.split('.').join('-');
 
     m.set(schemaId, createDefinition({
       schemaId,
+      viewSchemaId,
       kind,
       group,
       version,

--- a/templates/helpers.js
+++ b/templates/helpers.js
@@ -150,7 +150,7 @@ const createLinkToObject = config => schemaProps => {
   //if(!schemaProps.type) console.log(`${schemaProps['$ref']}:${schemaProps.type}`);
   const ref = config.refs[schemaProps['$ref'].replace('#/definitions/', '')];
   if(ref)
-    return `../${ref.path}/${ref.filename}#${ref.anchor}`;
+    return `../${ref.path}/${ref.filename}#${ref.anchor.split('.').join('-')}`;
 
   return '';
 }
@@ -165,7 +165,7 @@ const createLinkToObject = config => schemaProps => {
 const createLinkToResource = config => obj => {
   const ref = config.refs[obj.schemaId];
   if(ref)
-    return `./${ref.path}/${ref.filename}#${ref.anchor}`;
+    return `../${ref.path}/${ref.filename}#${ref.anchor}`;
 
   return '';
 }

--- a/templates/pages/objects.hbs
+++ b/templates/pages/objects.hbs
@@ -9,7 +9,7 @@ toc::[]
 
 {{#each .}}
 {{#with (findDefinitionByKey .)}}
-[id="{{schemaId}}"]
+[id="{{viewSchemaId}}"]
 == {{schemaId}} schema
 
 {{#each propertiesByPath~}}


### PR DESCRIPTION
There is a need for the new interface for these docs to have nothing in the root directory. As a result, this commit updates the location of the generated index.adoc file so that it is instead generated in the rest_api/overview directory. Additionally, this commit also updates the relative path of the content links generated to point to the correct directory for the index file now that it is nested.

Finally, this commit also resolves another issue with these relative links: it replaces the periods in the generated names based on the api schema and replaces them with hyphens so that they can resolve properly.